### PR TITLE
feat: add new grey to palette

### DIFF
--- a/src/example.js
+++ b/src/example.js
@@ -6,6 +6,7 @@ const colors = [
   [ 'kiev', '#383E42' ],
   [ 'moscow', '#7A7A7A' ],
   [ 'london', '#B6B6B6' ],
+  [ 'cardiff', '#D7D7D7' ],
   [ 'berlin', '#F2F2F2' ],
   [ 'thimphu', '#FFFFFF' ],
   [ 'honolulu', '#16C9B3' ],

--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,7 @@
   --color-kiev: #383e42;
   --color-moscow: #7a7a7a;
   --color-london: #b6b6b6;
+  --color-cardiff: #d7d7d7;
   --color-berlin: #f2f2f2;
   --color-thimphu: #fff;
   --color-honolulu: #16c9b3;


### PR DESCRIPTION
We need a new grey in between the very light and mid grey to use for the horizontal rules used throughout the site.

The current colour has been deemed too light and hard to distinguish on some monitors and the next grey up is too dark.